### PR TITLE
Adds support for member expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.4.0
+- Added support for  
+
 ## 0.3.0
 - Added support for checking constructors
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ rules: {
   "require-explicit-generics/require-explicit-generics": [
     "error",
     // List your functions here
-    [ "myFunction", "myOtherFunction" ]
+    [ "myFunction", "myVar.myOtherFunction" ]
   ]
 },
 ```
@@ -53,10 +53,10 @@ You can also use a map to define how many generics to expect for each function.
 rules: {
   "require-explicit-generics/require-explicit-generics": [
     "error",
-    { "myFunction": 1, "myOtherFunction": 2 }
+    { "myFunction": 1, "myVar.myOtherFunction": 2 }
   ]
 },
 ```
 ```ts
-myOtherFunction<TypeA>(); // Function 'myOtherFunction' called with too few explicit generics...
+myFunction<TypeA>(); // Function 'myOtherFunction' called with too few explicit generics...
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eslint-plugin-require-explicit-generics",
   "description": "Force configured functions to include explicit generics",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "index.js",
   "homepage": "https://github.com/mattorchard/eslint-plugin-require-explicit-generics",
   "repository": {


### PR DESCRIPTION
* Adds support for member expressions and member-like expressions
* Adds syntax support for matching `foo.bar()` with any of `foo.bar`, `*.bar` `bar` (with the more specific taking precedence)